### PR TITLE
fix: clarification and namespace change of module

### DIFF
--- a/ImageAnnotator.php
+++ b/ImageAnnotator.php
@@ -1,8 +1,8 @@
-<?php namespace BrownCCV\ImageViewerAnnotate;
+<?php namespace BrownCCV\ImageAnnotator;
 
 if (!class_exists("Util")) include_once("classes/Util.php");
 
-use DE\RUB\ImageViewerAnnotateExternalModule\Project;
+use DE\RUB\ImageAnnotatorExternalModule\Project;
 use \REDCap as REDCap;
 use \Files as Files;
 use \Piping as Piping;
@@ -10,7 +10,7 @@ use \Event as Event;
 
 use BrownCCV\Utility\ActionTagHelper;
 
-class ImageViewerAnnotate extends \ExternalModules\AbstractExternalModule {
+class ImageAnnotator extends \ExternalModules\AbstractExternalModule {
 
     private $imageViewTag = "@IMAGE-ANNOTATE-UPLOAD";
     private $imagePipeTag = "@IMAGE-ANNOTATE";
@@ -46,7 +46,7 @@ class ImageViewerAnnotate extends \ExternalModules\AbstractExternalModule {
                 <script>IVEM.interval = window.setInterval(IVEM.highlightFields, 1000);</script>
             <?php
         }
-        // Announce that this project is using the Image Viewer EM
+        // Announce that this project is using the Image Annotator EM
         if (PAGE == "ProjectSetup/index.php") {
             $this->renderJavascriptSetup();
             ?>
@@ -222,7 +222,7 @@ class ImageViewerAnnotate extends \ExternalModules\AbstractExternalModule {
         // Get from action tags (and only take if not specified in external module settings)
         if (!class_exists("\BrownCCV\Utility\ActionTagHelper")) include_once("classes/ActionTagHelper.php");
 
-        if (!class_exists("\DE\RUB\ImageViewerAnnotateExternalModule\Project")) include_once ("classes/Project.php");
+        if (!class_exists("\DE\RUB\ImageAnnotatorExternalModule\Project")) include_once ("classes/Project.php");
         $project = new Project($this->framework, $project_id ?: $this->framework->getProjectId());
 
         $field_params = array();
@@ -277,7 +277,7 @@ class ImageViewerAnnotate extends \ExternalModules\AbstractExternalModule {
         }
         $payload = urlencode($payload);
         ?>
-            <script src="<?php print $this->getUrl('js/imageViewerAnnotate.js'); ?>"></script>
+            <script src="<?php print $this->getUrl('js/ImageAnnotator.js'); ?>"></script>
             <script src="<?php print $this->getUrl('js/markerjs2.js'); ?>"></script>
             <script>
                 IVEM.valid_image_suffixes = <?php print json_encode($this->valid_image_suffixes) ?>;
@@ -302,7 +302,7 @@ class ImageViewerAnnotate extends \ExternalModules\AbstractExternalModule {
      */
     function renderPreview($project_id, $instrument, $record, $event_id, $instance, $survey_hash = null) {
 
-        if (!class_exists("\DE\RUB\ImageViewerAnnotateExternalModule\Project")) include_once ("classes/Project.php");
+        if (!class_exists("\DE\RUB\ImageAnnotatorExternalModule\Project")) include_once ("classes/Project.php");
         $project = new Project($this->framework, $project_id);
 
         $active_field_params = $this->getFieldParams();

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Image Annotate
+# Image Annotator
 
 A REDCap external module (EM) that modifies the [Image Viewer EM](https://github.com/susom/redcap-em-image-viewer) to annotate uploaded images (using [markerjs2](https://markerjs.com/)) in notes box field types.
 
@@ -6,7 +6,7 @@ A REDCap external module (EM) that modifies the [Image Viewer EM](https://github
 
 ## Instructions
 
-1. Enable the Image Annotate EM through REDCap's control center
+1. Enable the Image Annotator EM through REDCap's control center
 2. Create a new project and enable surveys in your project
 3. Create a new instrument in the project designer with the following:
     - Add a field with using the **File Upload** field type, your variable name (e.g., `img_upload`), and `@IMAGE-ANNOTATE-UPLOAD` action tag

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Image Viewer and Annotate
+# Image Annotate
 
 A REDCap external module (EM) that modifies the [Image Viewer EM](https://github.com/susom/redcap-em-image-viewer) to annotate uploaded images (using [markerjs2](https://markerjs.com/)) in notes box field types.
 
@@ -6,7 +6,7 @@ A REDCap external module (EM) that modifies the [Image Viewer EM](https://github
 
 ## Instructions
 
-1. Enable the Image Viewer and Annotate EM through REDCap's control center
+1. Enable the Image Annotate EM through REDCap's control center
 2. Create a new project and enable surveys in your project
 3. Create a new instrument in the project designer with the following:
     - Add a field with using the **File Upload** field type, your variable name (e.g., `img_upload`), and `@IMAGE-ANNOTATE-UPLOAD` action tag

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Image Viewer and Annotate
 
-A REDCap external module (EM) that extends the [Image Viewer EM](https://github.com/susom/redcap-em-image-viewer) to annotate uploaded images (using [markerjs2](https://markerjs.com/)) in notes box field types.
+A REDCap external module (EM) that modifies the [Image Viewer EM](https://github.com/susom/redcap-em-image-viewer) to annotate uploaded images (using [markerjs2](https://markerjs.com/)) in notes box field types.
+
+**NOTE**: This EM does not include the [Image Viewer EM's](https://github.com/susom/redcap-em-image-viewer) action tags.
 
 ## Instructions
 
 1. Enable the Image Viewer and Annotate EM through REDCap's control center
 2. Create a new project and enable surveys in your project
 3. Create a new instrument in the project designer with the following:
-    - Add a field with using the **File Upload** field type, your variable name (e.g., `img_view`), and `@IMAGE-ANNOTATE-UPLOAD` action tag
-    - Add another field with the **Notes Box** field type, your variable name (e.g., `img_annotate`), and `@IMAGE-ANNOTATE` action tag assigned to your image upload variable name (e.g., `@IMAGE-ANNOTATE="img_view"`)
+    - Add a field with using the **File Upload** field type, your variable name (e.g., `img_upload`), and `@IMAGE-ANNOTATE-UPLOAD` action tag
+    - Add another field with the **Notes Box** field type, your variable name (e.g., `img_annotate`), and `@IMAGE-ANNOTATE` action tag assigned to your image upload variable name (e.g., `@IMAGE-ANNOTATE="img_upload"`)
 
 ## Supported File Types
 
-- JPEG (.jpeg, jpg, jpe)
+- JPEG (.jpeg, .jpg, .jpe)
 - PNG (.png)
 - TIF (.tiff)
 - GIF (.gif)

--- a/classes/Project.php
+++ b/classes/Project.php
@@ -1,4 +1,4 @@
-<?php namespace DE\RUB\ImageViewerAnnotateExternalModule;
+<?php namespace DE\RUB\ImageAnnotatorExternalModule;
 
 class Project
 {
@@ -29,7 +29,7 @@ class Project
      * @return Record 
      */
     function getRecord($record_id) {
-        if (!class_exists("\DE\RUB\ImageViewerAnnotateExternalModule\Record")) include_once ("Record.php");
+        if (!class_exists("\DE\RUB\ImageAnnotatorExternalModule\Record")) include_once ("Record.php");
         return new Record($this->framework, $this, $record_id);
     }
 

--- a/classes/Record.php
+++ b/classes/Record.php
@@ -1,4 +1,4 @@
-<?php namespace DE\RUB\ImageViewerAnnotateExternalModule;
+<?php namespace DE\RUB\ImageAnnotatorExternalModule;
 
 use \REDCap;
 

--- a/classes/Util.php
+++ b/classes/Util.php
@@ -1,5 +1,5 @@
 <?php
-namespace BrownCCV\ImageViewerAnnotate;
+namespace BrownCCV\ImageAnnotator;
 
 class Util
 {

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
-  "name": "Image Annotate",
+  "name": "Image Annotator",
 
-  "namespace":"BrownCCV\\ImageViewerAnnotate",
+  "namespace":"BrownCCV\\ImageAnnotator",
 
   "description": "Annotate uploaded images on a form/survey",
 
@@ -51,7 +51,7 @@
     },
     {
       "key": "active-fields",
-      "name": "Configure one or more file-upload fields to activate ImageViewerAnnotate preview:",
+      "name": "Configure one or more file-upload fields to activate Image Annotator preview:",
       "required": false,
       "type": "sub_settings",
       "repeatable": true,

--- a/config.json
+++ b/config.json
@@ -1,9 +1,9 @@
 {
-  "name": "Image Viewer and Annotate",
+  "name": "Image Annotate",
 
   "namespace":"BrownCCV\\ImageViewerAnnotate",
 
-  "description": "Preview and annotate uploaded images on a form/survey",
+  "description": "Annotate uploaded images on a form/survey",
 
   "framework-version": 3,
 

--- a/js/imageAnnotator.js
+++ b/js/imageAnnotator.js
@@ -64,13 +64,13 @@ IVEM.highlightFields = function () {
     if (tr.length) {
       var icon_div = $(".frmedit_icons", tr);
       var label = $(
-        '<div style="float:right;margin-right:1em;"><i class="far fa-eye"></i> <i>Image Viewer</i></div>'
+        '<div style="float:right;margin-right:1em;"><i class="far fa-eye"></i> <i>Image Annotator</i></div>'
       )
         .addClass("label label-primary em-label text-dark")
         .attr("data-toggle", "tooltip")
         .attr(
           "title",
-          "The content of this field is customized by the Image Viewer External Module" +
+          "The content of this field is customized by the Image Annotator External Module" +
             (params ? ":\n" + JSON.stringify(params) : "")
         )
         .on("click", function () {

--- a/js/imageViewerAnnotate.js
+++ b/js/imageViewerAnnotate.js
@@ -349,11 +349,11 @@ IVEM.projectSetup = function () {
         );
       }
 
-      var label = $("<span>ImageViewer</span>")
+      var label = $("<span>ImageAnnotate</span>")
         .addClass("label label-primary label-lg em-label")
         .attr(
           "title",
-          "The content of this project is customized by the Image Viewer External Module"
+          "The content of this project is customized by the Image Annotator External Module"
         );
 
       var badge = $("<span></span>")

--- a/js/imageViewerAnnotate.js
+++ b/js/imageViewerAnnotate.js
@@ -2,6 +2,11 @@ var IVEM = IVEM || {};
 
 // Shows marker along with inserting marker data into text field
 function showMarkerArea(target, source, input) {
+  // Continue only if the target image is positioned
+  if (target.x === 0) {
+    setTimeout(showMarkerArea, 500, target, source, input)
+    return
+  }
   const markerArea = new markerjs2.MarkerArea(source);
   // Limit available markers
   markerArea.availableMarkerTypes = ["FreehandMarker"];
@@ -280,13 +285,7 @@ IVEM.insertPreview = function (field, params) {
           const text_input = $(
             target_img.closest("tr").getElementsByTagName("textarea")[0]
           );
-          console.log(source_img.complete, source_img.naturalHeight, source_img.naturalWidth, source_img.height, source_img.width, source_img);
-          if (source_img.naturalHeight != source_img.height) {
-            console.log("show annotation options");
-            showMarkerArea(target_img, source_img, text_input);
-          }
-          // console.log(target_img.complete, target_img.naturalHeight, target_img.naturalWidth, target_img.height, target_img.width);
-          // showMarkerArea(target_img, source_img, text_input);
+          showMarkerArea(target_img, source_img, text_input);
         });
       }
 


### PR DESCRIPTION
This PR:

- clarifies that our module modifies the Image Viewer module rather than extends it (Closes #47, Closes #48)
- clarifies that the configuration preview is for this module and not the Image Viewer EM (Closes #49)
- makes misc. namespace changes from phrases like "Image Viewer" to "Image Annotator" 